### PR TITLE
DCS-497 simplifying tracking different sample modifications

### DIFF
--- a/src/main/java/uk/gov/justice/hmiprobation/casesampler/dto/Sample.kt
+++ b/src/main/java/uk/gov/justice/hmiprobation/casesampler/dto/Sample.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.hmiprobation.casesampler.dto
 
 import uk.gov.justice.hmiprobation.casesampler.services.AllocationData
-import uk.gov.justice.hmiprobation.casesampler.utils.Size.SampleSize
+import uk.gov.justice.hmiprobation.casesampler.utils.SampleSize
 import java.time.LocalDateTime
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger

--- a/src/main/java/uk/gov/justice/hmiprobation/casesampler/services/AllocationCalculator.kt
+++ b/src/main/java/uk/gov/justice/hmiprobation/casesampler/services/AllocationCalculator.kt
@@ -2,12 +2,11 @@ package uk.gov.justice.hmiprobation.casesampler.services
 
 import org.slf4j.LoggerFactory
 import uk.gov.justice.hmiprobation.casesampler.dto.Case
-import uk.gov.justice.hmiprobation.casesampler.utils.Size
-import uk.gov.justice.hmiprobation.casesampler.utils.Size.SampleSize
+import uk.gov.justice.hmiprobation.casesampler.utils.SampleSize
 import uk.gov.justice.hmiprobation.casesampler.utils.calculateSampleSize
 import kotlin.random.Random
 
-data class Info(val id: String, val size: Size)
+data class Info(val id: String, val size: SampleSize)
 
 data class AllocationData(val cluster: Info, val ldu: Info, val ro: Info)
 
@@ -27,7 +26,7 @@ class AllocationCalculator(val roAllocationAdjuster: RoAllocationAdjuster) {
     fun calculate(size: SampleSize, cases: List<Case>): List<RoAllocation> {
         val casesByCluster = cases.groupBy { it.cluster }
 
-        val clusterSizes = calculateSampleSize(size.numberOfSamples, casesByCluster)
+        val clusterSizes = calculateSampleSize(size.count, casesByCluster)
 
         return clusterSizes.fold(mutableListOf()) { result, (cluster, size) ->
             result.addAll(toRoAllocation(Info(cluster, size), casesByCluster[cluster]!!))

--- a/src/main/java/uk/gov/justice/hmiprobation/casesampler/utils/SampleSizeCalculator.kt
+++ b/src/main/java/uk/gov/justice/hmiprobation/casesampler/utils/SampleSizeCalculator.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.hmiprobation.casesampler.utils
+
+import uk.gov.justice.hmiprobation.casesampler.utils.Type.*
+import kotlin.math.roundToInt
+
+data class Result<K>(val key: K, val size: SampleSize)
+typealias SampleSizes<K> = List<Result<K>>
+
+fun <K> calculateSampleSize(
+        numberOfSamples: Int,
+        groupedByType: Map<K, List<Any>>,
+        bufferPercentage: Double = 0.0): SampleSizes<K> {
+    val proportions = calculateProportions(groupedByType)
+    val results = proportions.map { (type, proportion) ->
+        Result(type, toSampleSize(numberOfSamples, bufferPercentage, proportion))
+    }
+    return results
+}
+
+fun <K> calculateProportions(groupedByType: Map<K, List<Any>>): Map<K, Double> {
+    val totalCases = groupedByType.values.map { it.size }.sum()
+    return groupedByType.mapValues { (it.value.size.toDouble() / totalCases) }
+}
+
+fun toSampleSize(numberOfSamples: Int, bufferPercentage: Double, proportion: Double): SampleSize {
+    val base = (numberOfSamples * proportion).roundToInt()
+    val buffer = ((base.toDouble() / 100) * bufferPercentage).roundToInt()
+    val originalPercentage = "%.2f".format(proportion * 100)
+
+    return if (buffer > 0) {
+        SampleSize(base, originalPercentage).update(WITH_BUFFER, base + buffer)
+    } else {
+        SampleSize(base, originalPercentage)
+    }
+}

--- a/src/test/java/uk/gov/justice/hmiprobation/casesampler/services/AllocationCalculatorTest.kt
+++ b/src/test/java/uk/gov/justice/hmiprobation/casesampler/services/AllocationCalculatorTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.hmiprobation.casesampler.dto.Gender.MALE
 import uk.gov.justice.hmiprobation.casesampler.dto.RiskOfSeriousHarmLevel
 import uk.gov.justice.hmiprobation.casesampler.dto.SentenceType
 import uk.gov.justice.hmiprobation.casesampler.utils.Result
-import uk.gov.justice.hmiprobation.casesampler.utils.Size.SampleSize
+import uk.gov.justice.hmiprobation.casesampler.utils.SampleSize
 import java.time.LocalDate
 
 @ExtendWith(MockKExtension::class)
@@ -53,25 +53,25 @@ class AllocationCalculatorTest {
         assertThat(data).hasSize(4)
         assertThat(data).filteredOn { it.cluster.id == "N01" }.containsExactly(
                 AllocationData(
-                        cluster = Info("N01", SampleSize(2, 2, "50.00")),
-                        ldu = Info("N01AAA", SampleSize(1, 1, "50.00")),
-                        ro = Info("ro1", SampleSize(1, 1, "100.00"))
+                        cluster = Info("N01", SampleSize(2, "50.00")),
+                        ldu = Info("N01AAA", SampleSize(1, "50.00")),
+                        ro = Info("ro1", SampleSize(1, "100.00"))
                 ),
                 AllocationData(
-                        cluster = Info("N01", SampleSize(2, 2, "50.00")),
-                        ldu = Info("N01BBB", SampleSize(1, 1, "50.00")),
-                        ro = Info("ro2", SampleSize(1, 1, "100.00"))
+                        cluster = Info("N01", SampleSize(2, "50.00")),
+                        ldu = Info("N01BBB", SampleSize(1, "50.00")),
+                        ro = Info("ro2", SampleSize(1, "100.00"))
                 ))
         assertThat(data).filteredOn { it.cluster.id == "N02" }.containsExactly(
                 AllocationData(
-                        cluster = Info("N02", SampleSize(2, 2, "50.00")),
-                        ldu = Info("N02AAA", SampleSize(1, 1, "50.00")),
-                        ro = Info("ro1", SampleSize(1, 1, "100.00"))
+                        cluster = Info("N02", SampleSize(2, "50.00")),
+                        ldu = Info("N02AAA", SampleSize(1, "50.00")),
+                        ro = Info("ro1", SampleSize(1, "100.00"))
                 ),
                 AllocationData(
-                        cluster = Info("N02", SampleSize(2, 2, "50.00")),
-                        ldu = Info("N02BBB", SampleSize(1, 1, "50.00")),
-                        ro = Info("ro2", SampleSize(1, 1, "100.00"))
+                        cluster = Info("N02", SampleSize(2, "50.00")),
+                        ldu = Info("N02BBB", SampleSize(1, "50.00")),
+                        ro = Info("ro2", SampleSize(1, "100.00"))
                 ))
     }
 
@@ -118,8 +118,8 @@ class AllocationCalculatorTest {
 
         val data = results.map { it.allocationData }
         assertThat(data).hasSize(2)
-        assertThat(data.find { it.cluster.id == "N01" }).extracting { it!!.cluster }.isEqualTo(Info("N01", SampleSize(1, 1, "33.33")))
-        assertThat(data.find { it.cluster.id == "N02" }).extracting { it!!.cluster }.isEqualTo(Info("N02", SampleSize(3, 3, "66.67")))
+        assertThat(data.find { it.cluster.id == "N01" }).extracting { it!!.cluster }.isEqualTo(Info("N01", SampleSize(1, "33.33")))
+        assertThat(data.find { it.cluster.id == "N02" }).extracting { it!!.cluster }.isEqualTo(Info("N02", SampleSize(3, "66.67")))
 
         val cases = results.flatMap { it.getRandomSamples() }
         assertThat(cases).filteredOn { it.cluster == "N01" }.hasSize(1)
@@ -140,8 +140,8 @@ class AllocationCalculatorTest {
 
         val data = results.map { it.allocationData }
         assertThat(data).hasSize(2)
-        assertThat(data.find { it.ldu.id == "N01AAA" }).extracting { it!!.ldu }.isEqualTo(Info("N01AAA", SampleSize(1, 1, "33.33")))
-        assertThat(data.find { it.ldu.id == "N01BBB" }).extracting { it!!.ldu }.isEqualTo(Info("N01BBB", SampleSize(3, 3, "66.67")))
+        assertThat(data.find { it.ldu.id == "N01AAA" }).extracting { it!!.ldu }.isEqualTo(Info("N01AAA", SampleSize(1, "33.33")))
+        assertThat(data.find { it.ldu.id == "N01BBB" }).extracting { it!!.ldu }.isEqualTo(Info("N01BBB", SampleSize(3, "66.67")))
 
         val cases = results.flatMap { it.getRandomSamples() }
         assertThat(cases).filteredOn { it.ldu == "N01AAA" }.hasSize(1)
@@ -162,8 +162,8 @@ class AllocationCalculatorTest {
 
         val data = results.map { it.allocationData }
         assertThat(data).hasSize(2)
-        assertThat(data.find { it.ro.id == "ro1" }).extracting { it!!.ro }.isEqualTo(Info("ro1", SampleSize(1, 1, "33.33")))
-        assertThat(data.find { it.ro.id == "ro2" }).extracting { it!!.ro }.isEqualTo(Info("ro2", SampleSize(3, 3, "66.67")))
+        assertThat(data.find { it.ro.id == "ro1" }).extracting { it!!.ro }.isEqualTo(Info("ro1", SampleSize(1, "33.33")))
+        assertThat(data.find { it.ro.id == "ro2" }).extracting { it!!.ro }.isEqualTo(Info("ro2", SampleSize(3, "66.67")))
 
         val cases = results.flatMap { it.getRandomSamples() }
         assertThat(cases).filteredOn { it.responsibleOfficer == "ro1" }.hasSize(1)

--- a/src/test/java/uk/gov/justice/hmiprobation/casesampler/services/SamplePickerTest.kt
+++ b/src/test/java/uk/gov/justice/hmiprobation/casesampler/services/SamplePickerTest.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.hmiprobation.casesampler.dto.Stratum
 import uk.gov.justice.hmiprobation.casesampler.dto.Stratum.FEMALE
 import uk.gov.justice.hmiprobation.casesampler.dto.Stratum.MALE_COMMUNITY_LOW
 import uk.gov.justice.hmiprobation.casesampler.utils.Result
-import uk.gov.justice.hmiprobation.casesampler.utils.Size.SampleSize
+import uk.gov.justice.hmiprobation.casesampler.utils.SampleSize
 import java.time.LocalDate
 import kotlin.random.Random
 

--- a/src/test/java/uk/gov/justice/hmiprobation/casesampler/utils/SampleSizeCalculatorTest.kt
+++ b/src/test/java/uk/gov/justice/hmiprobation/casesampler/utils/SampleSizeCalculatorTest.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.hmiprobation.casesampler.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import uk.gov.justice.hmiprobation.casesampler.utils.SampleSizeCalculatorTest.TestType.A
+import uk.gov.justice.hmiprobation.casesampler.utils.SampleSizeCalculatorTest.TestType.B
+import uk.gov.justice.hmiprobation.casesampler.utils.SampleSizeCalculatorTest.TestType.C
+import uk.gov.justice.hmiprobation.casesampler.utils.SampleSizeCalculatorTest.TestType.D
+import uk.gov.justice.hmiprobation.casesampler.utils.SampleSizeCalculatorTest.TestType.E
+import uk.gov.justice.hmiprobation.casesampler.utils.Type.WITH_BUFFER
+
+
+class SampleSizeCalculatorTest {
+
+    enum class TestType { A, B, C, D, E }
+
+    fun listOfSize(i: Int) = (1..i).toList()
+
+    @Test
+    fun `Check simple example`() {
+
+        val sizes = calculateSampleSize(10, mapOf(
+                A to listOfSize(50),
+                B to listOfSize(50)))
+
+        assertThat(sizes).isEqualTo(listOf(
+                Result(A, SampleSize(5, "50.00")),
+                Result(B, SampleSize(5, "50.00"))
+        ))
+    }
+
+    @Test
+    fun `can end up with less samples than requested`() {
+
+        val sizes = calculateSampleSize(10, mapOf(
+                A to listOfSize(50),
+                B to listOfSize(50),
+                C to listOfSize(50)
+        ))
+
+        assertThat(sizes).isEqualTo(listOf(
+                Result(A, SampleSize(3, "33.33")),
+                Result(B, SampleSize(3, "33.33")),
+                Result(C, SampleSize(3, "33.33"))
+        ))
+    }
+
+    @Test
+    fun `example from doc`() {
+
+        val sizes = calculateSampleSize(148, mapOf(
+                A to listOfSize(454),
+                B to listOfSize(138),
+                C to listOfSize(327),
+                D to listOfSize(129),
+                E to listOfSize(169)
+        ))
+
+        assertThat(sizes).isEqualTo(listOf(
+                Result(A, SampleSize(55, "37.30")),
+                Result(B, SampleSize(17, "11.34")),
+                Result(C, SampleSize(40, "26.87")),
+                Result(D, SampleSize(16, "10.60")),
+                Result(E, SampleSize(21, "13.89"))
+        ))
+    }
+
+    @Test
+    fun `example from doc with 20% buffer`() {
+
+        val sizes = calculateSampleSize(148, mapOf(
+                A to listOfSize(454),
+                B to listOfSize(138),
+                C to listOfSize(327),
+                D to listOfSize(129),
+                E to listOfSize(169)
+        ), 20.00)
+
+        assertThat(sizes).isEqualTo(listOf(
+                Result(A, SampleSize(55, "37.30").update(WITH_BUFFER, 66)),
+                Result(B, SampleSize(17, "11.34").update(WITH_BUFFER, 20)),
+                Result(C, SampleSize(40, "26.87").update(WITH_BUFFER, 48)),
+                Result(D, SampleSize(16, "10.60").update(WITH_BUFFER, 19)),
+                Result(E, SampleSize(21, "13.89").update(WITH_BUFFER, 25))
+        ))
+    }
+
+    @Disabled("Being fixed as part of DCS-497" )
+    @Test
+    fun `check rounding we don't get more samples than requested due to rounding `() {
+
+        (0..90).forEach {
+            val sizes = calculateSampleSize(it, mapOf(
+                    A to listOfSize(60),
+                    B to listOfSize(30),
+                    C to listOfSize(30)
+            ))
+
+            assertThat(sizes.map { it.size.count }.sum()).isEqualTo(it)
+        }
+    }
+}

--- a/src/test/java/uk/gov/justice/hmiprobation/casesampler/utils/SampleSizeTest.kt
+++ b/src/test/java/uk/gov/justice/hmiprobation/casesampler/utils/SampleSizeTest.kt
@@ -2,86 +2,101 @@ package uk.gov.justice.hmiprobation.casesampler.utils
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.hmiprobation.casesampler.utils.CasesTest.Type.A
-import uk.gov.justice.hmiprobation.casesampler.utils.CasesTest.Type.B
-import uk.gov.justice.hmiprobation.casesampler.utils.CasesTest.Type.C
-import uk.gov.justice.hmiprobation.casesampler.utils.CasesTest.Type.D
-import uk.gov.justice.hmiprobation.casesampler.utils.CasesTest.Type.E
-import uk.gov.justice.hmiprobation.casesampler.utils.Size.SampleSize
+import uk.gov.justice.hmiprobation.casesampler.utils.Type.DECREASED_FOR_RO
+import uk.gov.justice.hmiprobation.casesampler.utils.Type.INCREASED_FOR_RO
+import uk.gov.justice.hmiprobation.casesampler.utils.Type.INITIAL
+import uk.gov.justice.hmiprobation.casesampler.utils.Type.WITH_BUFFER
 
 
-class CasesTest {
-
-    enum class Type { A, B, C, D, E }
-
-    fun listOfSize(i: Int) = (1..i).toList()
+class SampleSizeTest {
 
     @Test
-    fun `Check simple example`() {
+    fun `check update`() {
 
-        val sizes = calculateSampleSize(10, mapOf(
-                A to listOfSize(50),
-                B to listOfSize(50)))
-
-        assertThat(sizes).isEqualTo(listOf(
-                Result(A, SampleSize(5, "50.00")),
-                Result(B, SampleSize(5, "50.00"))
-        ))
+        assertThat(
+                SampleSize(1, "100%")
+                        .update(WITH_BUFFER, 5)
+        ).isEqualTo(
+                SampleSize(5, "100%", WITH_BUFFER, listOf(
+                        PreviousValue(INITIAL, 1)
+                ))
+        )
     }
 
     @Test
-    fun `can end up with less samples than requested`() {
+    fun `check multiple updates`() {
 
-        val sizes = calculateSampleSize(10, mapOf(
-                A to listOfSize(50),
-                B to listOfSize(50),
-                C to listOfSize(50)
-        ))
+        assertThat(
+                SampleSize(1, "100%")
+                        .update(WITH_BUFFER, 5)
+                        .update(INCREASED_FOR_RO, 4)
+                        .update(DECREASED_FOR_RO, 6)
+        ).isEqualTo(
+                SampleSize(6, "100%", DECREASED_FOR_RO, listOf(
+                        PreviousValue(INITIAL, 1),
+                        PreviousValue(WITH_BUFFER, 5),
+                        PreviousValue(INCREASED_FOR_RO, 4)
+                ))
+        )
 
-        assertThat(sizes).isEqualTo(listOf(
-                Result(A, SampleSize(3, "33.33")),
-                Result(B, SampleSize(3, "33.33")),
-                Result(C, SampleSize(3, "33.33"))
-        ))
     }
 
     @Test
-    fun `example from doc`() {
+    fun `update ignores merges subsequent event types`() {
 
-        val sizes = calculateSampleSize(148, mapOf(
-                A to listOfSize(454),
-                B to listOfSize(138),
-                C to listOfSize(327),
-                D to listOfSize(129),
-                E to listOfSize(169)
-        ))
-
-        assertThat(sizes).isEqualTo(listOf(
-                Result(A, SampleSize(55, "37.30")),
-                Result(B, SampleSize(17, "11.34")),
-                Result(C, SampleSize(40, "26.87")),
-                Result(D, SampleSize(16, "10.60")),
-                Result(E, SampleSize(21, "13.89"))
-        ))
+        assertThat(
+                SampleSize(1, "100%")
+                        .update(WITH_BUFFER, 5)
+                        .update(WITH_BUFFER, 6)
+                        .update(INCREASED_FOR_RO, 4)
+                        .update(INCREASED_FOR_RO, 2)
+                        .update(WITH_BUFFER, 6)
+                        .update(DECREASED_FOR_RO, 7)
+        ).isEqualTo(
+                SampleSize(7, "100%", DECREASED_FOR_RO, listOf(
+                        PreviousValue(INITIAL, 1),
+                        PreviousValue(WITH_BUFFER, 6),
+                        PreviousValue(INCREASED_FOR_RO, 2),
+                        PreviousValue(WITH_BUFFER, 6)
+                ))
+        )
     }
 
     @Test
-    fun `example from doc with 20% buffer`() {
+    fun `check positive size of change`() {
 
-        val sizes = calculateSampleSize(148, mapOf(
-                A to listOfSize(454),
-                B to listOfSize(138),
-                C to listOfSize(327),
-                D to listOfSize(129),
-                E to listOfSize(169)
-        ), 20.00)
+        assertThat(SampleSize(1, "100%")
+                .update(WITH_BUFFER, 5)
+                .previousChange()).isEqualTo(4)
+    }
 
-        assertThat(sizes).isEqualTo(listOf(
-                Result(A, SampleSize(55, 66, "37.30")),
-                Result(B, SampleSize(17, 20, "11.34")),
-                Result(C, SampleSize(40, 48, "26.87")),
-                Result(D, SampleSize(16, 19, "10.60")),
-                Result(E, SampleSize(21, 25, "13.89"))
-        ))
+    @Test
+    fun `check negative size of change`() {
+
+        assertThat(SampleSize(5, "100%")
+                .update(WITH_BUFFER, 1)
+                .previousChange()).isEqualTo(-4)
+    }
+
+    @Test
+    fun `check size of change with merged events`() {
+
+        assertThat(SampleSize(1, "100%")
+                .update(WITH_BUFFER, 2)
+                .update(WITH_BUFFER, 4)
+                .update(WITH_BUFFER, 6)
+                .previousChange()
+        ).isEqualTo(5)
+    }
+
+    @Test
+    fun `check size of change is always based on last change`() {
+
+        assertThat(SampleSize(1, "100%")
+                .update(WITH_BUFFER, 2)
+                .update(INCREASED_FOR_RO, 4)
+                .update(DECREASED_FOR_RO, 6)
+                .previousChange()
+        ).isEqualTo(2)
     }
 }


### PR DESCRIPTION
 Removing sealed class and instead tracking history of sample sizes

This is in preparation for fixing rounding issues which I've captured in a disabled test

There are loads of cases of which a smaller sample needs to be reviewed by inspectors
The cases are broken down into different stratum based on categories and a representative amount of cases needs to be picked from each stratum
The number of cases picked used to be represented by a Size  which was either:
1.) SampleSize : which would include number of cases before and after an optional buffer was applied (they want a set % of extra cases just in case)
2.) Adjusted : only 6 at most cases can be taken from a specific responsible officer, if more then they need to be removed from the officer and allocated to other officers
I also need to apply some tweaks to the sizes where rounding can mean less than the number of requested samples can be returned due to rounding: If you have 3 equally represented stratums, and ask for 10 cases, with rounding you'd get 3 cases from each stratum - 9 cases, even though you asked for 10

They have provided an algorithm to tweak the number of samples when this happens
So rather than try to add another type (or types) to the sealed class to represent the possibility of having tweaked the score due to this rounding error, I've remodelled it so you just have one sample size type but it stores its history. So you can see what happened to it as different modification occurred to it
as shown in this lovely test:

```kotlin
      assertThat(
                SampleSize(1, "100%")
                        .update(WITH_BUFFER, 5)
                        .update(INCREASED_FOR_RO, 4)
                        .update(DECREASED_FOR_RO, 6)
        ).isEqualTo(
                SampleSize(6, "100%", DECREASED_FOR_RO, listOf(
                        PreviousValue(INITIAL, 1),
                        PreviousValue(WITH_BUFFER, 5),
                        PreviousValue(INCREASED_FOR_RO, 4)
                ))
        )
```