### PR TITLE
DCS-497 Rounding up/down sample size 

### DIFF
--- a/src/main/java/uk/gov/justice/hmiprobation/casesampler/utils/RoundingAdjuster.kt
+++ b/src/main/java/uk/gov/justice/hmiprobation/casesampler/utils/RoundingAdjuster.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.hmiprobation.casesampler.utils
+
+import uk.gov.justice.hmiprobation.casesampler.utils.Type.DECREASED_FOR_ROUNDING
+import uk.gov.justice.hmiprobation.casesampler.utils.Type.INCREASED_FOR_ROUNDING
+
+fun <K> adjustForRounding(numberOfSamples: Int, results: SampleSizes<K>): SampleSizes<K> {
+    val totalSampleSize = totalSize(results)
+    return when {
+        results.isEmpty() -> results
+        totalSampleSize < numberOfSamples -> addAdditionalSamples(numberOfSamples - totalSampleSize, results)
+        totalSampleSize > numberOfSamples -> removeAdditionalSamples(totalSampleSize - numberOfSamples, results)
+        else -> results
+    }
+}
+
+private fun <K> totalSize(results: SampleSizes<K>): Int = results.sumBy { (_, size) -> size.count }
+
+private fun <K> removeAdditionalSamples(samplesToRemove: Int, results: SampleSizes<K>): SampleSizes<K> {
+    val keyToSize = results.toMap().toMutableMap()
+    val infiniteKeys = infiniteKeysIterator(results.sortedByDescending { (_, size) -> size.count })
+
+    (0 until samplesToRemove).forEach { removeSample(keyToSize, infiniteKeys) }
+
+    return keyToSize.toList()
+}
+
+private fun <K> removeSample(keyToSize: MutableMap<K, SampleSize>, infiniteKeys: Iterator<K>) {
+    (0 until keyToSize.size).forEach {
+        val key = infiniteKeys.next()
+        if (keyToSize[key]!!.count > 0) {
+            keyToSize.computeIfPresent(key, { _, size -> size.update(DECREASED_FOR_ROUNDING, size.count - 1) })
+            return
+        }
+    }
+}
+
+private fun <K> addAdditionalSamples(samplesToAdd: Int, results: List<Result<K>>): List<Result<K>> {
+    val keyToSize = results.toMap().toMutableMap()
+    val infiniteKeys = infiniteKeysIterator(results.sortedBy { (_, size) -> size.count })
+    (0 until samplesToAdd).forEach {
+        val key = infiniteKeys.next()
+        keyToSize.computeIfPresent(key, { _, size -> size.update(INCREASED_FOR_ROUNDING, size.count + 1) })
+    }
+
+    return keyToSize.toList()
+}
+
+private fun <K> infiniteKeysIterator(results: List<Result<K>>) = generateSequence {
+    results
+            .map { (key, _) -> key }
+}.flatten().iterator()

--- a/src/main/java/uk/gov/justice/hmiprobation/casesampler/utils/SampleSize.kt
+++ b/src/main/java/uk/gov/justice/hmiprobation/casesampler/utils/SampleSize.kt
@@ -2,13 +2,13 @@ package uk.gov.justice.hmiprobation.casesampler.utils
 
 import uk.gov.justice.hmiprobation.casesampler.utils.Type.INITIAL
 
-enum class Type { INITIAL, WITH_BUFFER, ROUNDED, INCREASED_FOR_RO, DECREASED_FOR_RO }
+enum class Type { INITIAL, WITH_BUFFER, INCREASED_FOR_ROUNDING, DECREASED_FOR_ROUNDING, INCREASED_FOR_RO, DECREASED_FOR_RO }
 
 data class PreviousValue(val type: Type, val numberOfSamples: Int)
 
 data class SampleSize(
         val count: Int,
-        val originalPercentage: String,
+        val originalPercentage: String = "",
         val type: Type = INITIAL,
         val previousValues: List<PreviousValue> = listOf()) {
 

--- a/src/main/java/uk/gov/justice/hmiprobation/casesampler/utils/SampleSizeCalculator.kt
+++ b/src/main/java/uk/gov/justice/hmiprobation/casesampler/utils/SampleSizeCalculator.kt
@@ -1,20 +1,21 @@
 package uk.gov.justice.hmiprobation.casesampler.utils
 
-import uk.gov.justice.hmiprobation.casesampler.utils.Type.*
+import uk.gov.justice.hmiprobation.casesampler.utils.Type.WITH_BUFFER
 import kotlin.math.roundToInt
 
-data class Result<K>(val key: K, val size: SampleSize)
+typealias Result<K> = Pair<K, SampleSize>
 typealias SampleSizes<K> = List<Result<K>>
 
 fun <K> calculateSampleSize(
         numberOfSamples: Int,
         groupedByType: Map<K, List<Any>>,
         bufferPercentage: Double = 0.0): SampleSizes<K> {
-    val proportions = calculateProportions(groupedByType)
-    val results = proportions.map { (type, proportion) ->
+    val results = calculateProportions(groupedByType).map { (type, proportion) ->
         Result(type, toSampleSize(numberOfSamples, bufferPercentage, proportion))
     }
-    return results
+
+    val buffer = calculateBuffer(numberOfSamples, bufferPercentage)
+    return adjustForRounding(numberOfSamples + buffer, results)
 }
 
 fun <K> calculateProportions(groupedByType: Map<K, List<Any>>): Map<K, Double> {
@@ -24,7 +25,7 @@ fun <K> calculateProportions(groupedByType: Map<K, List<Any>>): Map<K, Double> {
 
 fun toSampleSize(numberOfSamples: Int, bufferPercentage: Double, proportion: Double): SampleSize {
     val base = (numberOfSamples * proportion).roundToInt()
-    val buffer = ((base.toDouble() / 100) * bufferPercentage).roundToInt()
+    val buffer = calculateBuffer(base, bufferPercentage)
     val originalPercentage = "%.2f".format(proportion * 100)
 
     return if (buffer > 0) {
@@ -33,3 +34,6 @@ fun toSampleSize(numberOfSamples: Int, bufferPercentage: Double, proportion: Dou
         SampleSize(base, originalPercentage)
     }
 }
+
+private fun calculateBuffer(numberOfSamples: Int, bufferPercentage: Double) =
+        ((numberOfSamples.toDouble() / 100) * bufferPercentage).roundToInt()

--- a/src/test/java/uk/gov/justice/hmiprobation/casesampler/services/AllocationCalculatorTest.kt
+++ b/src/test/java/uk/gov/justice/hmiprobation/casesampler/services/AllocationCalculatorTest.kt
@@ -25,8 +25,7 @@ class AllocationCalculatorTest {
     @BeforeEach
     fun setup() {
         every { roAllocationAdjuster.adjust(any()) } answers {
-            val results = it.invocation.args[0] as List<Result<String>>
-            results.map { RoSize(it.key, it.size) }
+             it.invocation.args[0] as List<Result<String>>
         }
     }
 
@@ -195,17 +194,16 @@ class AllocationCalculatorTest {
 
         val cases = results.flatMap { it.getRandomSamples() }
 
-        //Asked for 6 but got 7!
-        assertThat(cases).hasSize(7)
+        assertThat(cases).hasSize(6)
 
-        assertThat(cases).filteredOn { it.cluster == "N01" }.hasSize(5)
+        assertThat(cases).filteredOn { it.cluster == "N01" }.hasSize(4)
         assertThat(cases).filteredOn { it.cluster == "N02" }.hasSize(2)
         assertThat(cases).filteredOn { it.responsibleOfficer == "ro1" }.hasSize(1)
         assertThat(cases).filteredOn { it.responsibleOfficer == "ro2" }.hasSize(2)
-        assertThat(cases).filteredOn { it.responsibleOfficer == "ro3" }.hasSize(2)
+        assertThat(cases).filteredOn { it.responsibleOfficer == "ro3" }.hasSize(1)
         assertThat(cases).filteredOn { it.responsibleOfficer == "ro4" }.hasSize(2)
         assertThat(cases).filteredOn { it.ldu == "LDU01" }.hasSize(3)
-        assertThat(cases).filteredOn { it.ldu == "LDU02" }.hasSize(2)
+        assertThat(cases).filteredOn { it.ldu == "LDU02" }.hasSize(1)
         assertThat(cases).filteredOn { it.ldu == "LDU03" }.hasSize(2)
     }
 
@@ -300,7 +298,7 @@ class AllocationCalculatorTest {
         assertThat(data).hasSize(3)
 
         val cases = results.flatMap { it.getRandomSamples() }
-        assertThat(cases).hasSize(11)
+        assertThat(cases).hasSize(11) // TODO - can still get less samples than required due to RO allocation attempting to request more samples than present
 
         assertThat(cases).filteredOn { it.cluster == "N01" }.hasSize(11)
         assertThat(cases).filteredOn { it.responsibleOfficer == "ro1" }.hasSize(6)

--- a/src/test/java/uk/gov/justice/hmiprobation/casesampler/utils/RoundingAdjusterTest.kt
+++ b/src/test/java/uk/gov/justice/hmiprobation/casesampler/utils/RoundingAdjusterTest.kt
@@ -1,0 +1,87 @@
+package uk.gov.justice.hmiprobation.casesampler.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.hmiprobation.casesampler.utils.Type.DECREASED_FOR_ROUNDING
+import uk.gov.justice.hmiprobation.casesampler.utils.Type.INCREASED_FOR_ROUNDING
+
+class RoundingAdjusterTest {
+
+    @Test
+    fun `adjust empty`() {
+        val sampleSizes: SampleSizes<String> = listOf()
+        assertThat(adjustForRounding(0, sampleSizes)).isEmpty()
+    }
+
+    @Test
+    fun `adjust empty, asking for samples`() {
+        val sampleSizes: SampleSizes<String> = listOf()
+        assertThat(adjustForRounding(1, sampleSizes)).isEmpty()
+    }
+
+    @Test
+    fun `no adjustment needed`() {
+        val sampleSizes: SampleSizes<String> = listOf(size("k1", 10))
+
+        assertThat(adjustForRounding(10, sampleSizes)).isEqualTo(sampleSizes)
+    }
+
+    @Test
+    fun `one sample under (One type)`() {
+        val sampleSizes: SampleSizes<String> = listOf(size("k1", 9))
+        assertThat(adjustForRounding(10, sampleSizes)).containsExactly(
+                Result("k1", SampleSize(9).update(INCREASED_FOR_ROUNDING, 10))
+        )
+    }
+
+    @Test
+    fun `one sample under (Two types, only added to one of them)`() {
+        val sampleSizes: SampleSizes<String> = listOf(size("k1", 9), size("k2", 9))
+        assertThat(adjustForRounding(19, sampleSizes)).containsExactly(
+                Result("k1", SampleSize(9).update(INCREASED_FOR_ROUNDING, 10)),
+                Result("k2", SampleSize(9))
+        )
+    }
+
+    @Test
+    fun `two sample under (Three types, only added to two of them)`() {
+        val sampleSizes: SampleSizes<String> = listOf(size("k1", 9), size("k2", 9), size("k3", 9))
+        assertThat(adjustForRounding(29, sampleSizes)).containsExactly(
+                Result("k1", SampleSize(9).update(INCREASED_FOR_ROUNDING, 10)),
+                Result("k2", SampleSize(9).update(INCREASED_FOR_ROUNDING, 10)),
+                Result("k3", SampleSize(9))
+        )
+    }
+
+    @Test
+    fun `one sample over (One type)`() {
+        val sampleSizes: SampleSizes<String> = listOf(size("k1", 11))
+        assertThat(adjustForRounding(10, sampleSizes)).containsExactly(
+                Result("k1", SampleSize(11).update(DECREASED_FOR_ROUNDING, 10))
+        )
+    }
+
+    @Test
+    fun `Only modify largest types when more samples than requested`() {
+        val sampleSizes: SampleSizes<String> = listOf(size("k1", 6), size("k2", 10), size("k3", 4))
+        assertThat(adjustForRounding(18, sampleSizes)).containsExactly(
+                Result("k1", SampleSize(6).update(DECREASED_FOR_ROUNDING, 5)),
+                Result("k2", SampleSize(10).update(DECREASED_FOR_ROUNDING, 9)),
+                Result("k3", SampleSize(4))
+        )
+    }
+
+    @Test
+    fun `0 samples requested`() {
+        val sampleSizes: SampleSizes<String> = listOf(size("k1", 6), size("k2", 10), size("k3", 4))
+        assertThat(adjustForRounding(0, sampleSizes)).containsExactly(
+                Result("k1", SampleSize(6).update(DECREASED_FOR_ROUNDING, 0)),
+                Result("k2", SampleSize(10).update(DECREASED_FOR_ROUNDING, 0)),
+                Result("k3", SampleSize(4).update(DECREASED_FOR_ROUNDING, 0))
+        )
+    }
+
+
+    private fun size(key: String, size: Int) = Result(key, SampleSize(size))
+
+}


### PR DESCRIPTION
Due to rounding we can end up with a less the required amount of samples:

3 groups all with 10 samples - and we want 10 samples, we would try to request 33.3% of each group.
With rounding that would be 3 from each group : `3 * 3 != 10`

The strategy they use is to allocate cases to each group, smallest to largest until the desired sample size is met. 

They use the same sample to reduce the count (choosing 1 sample from the largest, next largest etc..)
